### PR TITLE
(MAINT) Replace Litmus install_pe rake task

### DIFF
--- a/splunk/Rakefile
+++ b/splunk/Rakefile
@@ -6,17 +6,18 @@ require 'puppet-strings/tasks' if Bundler.rubygems.find_name('puppet-strings').a
 require 'pry-byebug'
 require 'awesome_print'
 require 'colorize'
+require 'yaml'
 
 PuppetLint.configuration.send('disable_relative')
 
 def get_pe_master()
   provision_hash = YAML.load_file('./inventory.yaml')
-  provision_hash['groups'][1]['targets'][0]['name']
+  provision_hash['groups'][1]['targets'][0]['uri']
 end
 
 def get_splunk_server()
   provision_hash = YAML.load_file('./inventory.yaml')
-  provision_hash['groups'][1]['targets'][1]['name']
+  provision_hash['groups'][1]['targets'][1]['uri']
 end
 
 def module_path()
@@ -31,6 +32,63 @@ def aws_creds_setup()
       exit
     end
   end
+end
+
+def find_targets(inventory_hash, targets)
+  targets = if targets.nil?
+              inventory_hash.to_s.scan(%r{uri"=>"(\S*)"}).flatten
+            else
+              [targets]
+            end
+  targets
+end
+
+def install_pe(target_node_name)
+  inventory_hash = YAML.load_file('inventory.yaml')
+  target_nodes = find_targets(inventory_hash, target_node_name)
+  if target_nodes.empty?
+    puts 'No targets found'
+    exit 0
+  end
+  puts 'install_pe'
+  include BoltSpec::Run
+  Rake::Task['spec_prep'].invoke
+  config_data = { 'modulepath' => File.join(Dir.pwd, 'spec', 'fixtures', 'modules') }
+
+  puts 'Setting up parameters'
+
+  pe_release = 2019.2
+  pe_latest_cmd = "curl http://enterprise.delivery.puppetlabs.net/#{pe_release}/ci-ready/LATEST"
+  pe_latest = run_command(pe_latest_cmd, target_nodes, config: config_data, inventory: inventory_hash)
+  pe_latest_string = pe_latest[0]['result']['stdout'].delete("\n")
+  pe_file_name = "puppet-enterprise-#{pe_latest_string}-el-7-x86_64"
+  tar_file = "#{pe_file_name}.tar"
+  download_url = "http://enterprise.delivery.puppetlabs.net/#{pe_release}/ci-ready/#{tar_file}"
+
+  puts 'Initiating PE download'
+
+  # Download PE
+  download_pe_cmd = "wget -q #{download_url}"
+  run_command(download_pe_cmd, target_nodes, config: config_data, inventory: inventory_hash)
+
+  puts 'PE successfully downloaded, running installer (this may take 5 or so minutes, please be patient)'
+
+  # Install PE
+  untar_cmd = "tar xvf #{tar_file}"
+  run_command(untar_cmd, target_nodes, config: config_data, inventory: inventory_hash)
+  puts run_command("cd #{pe_file_name} && 1 | ./puppet-enterprise-installer", target_nodes, config: nil, inventory: inventory_hash)[0]['result']['stdout']
+
+  puts 'Autosigning Certificates'
+
+  # Set Autosign
+  autosign_cmd = "echo 'autosign = true' >> /etc/puppetlabs/puppet/puppet.conf"
+  run_command(autosign_cmd, target_nodes, config: config_data, inventory: inventory_hash)
+
+  puts 'Finishing installation with a Puppet Agent run'
+
+  run_command('puppet agent -t', target_nodes, config: config_data, inventory: inventory_hash)
+
+  puts 'PE Installation is now complete'
 end
 
 
@@ -54,7 +112,7 @@ task :provision_vmpooler do
   puts "Splunk Server #{splunk_server}".blue
 
   puts "Install Puppet Enterprise on the Puppet Master   [#{puppet_master}]".green
-  Rake::Task['litmus:install_pe'].invoke(puppet_master)
+  install_pe(puppet_master)
   puts "Installing the Puppet Agent on the Splunk server [#{splunk_server}]".green
   Rake::Task['litmus:install_agent'].invoke('puppet6', splunk_server)
   Rake::Task['litmus:install_agent'].reenable


### PR DESCRIPTION
The install_pe litmus rake task that we were using to install pe on
vmpooler resources was recently removed. This change ports that
functionality to a helper method in the rake file.