### PR TITLE
Add PDS setup automation bolt plan

### DIFF
--- a/pds_setup/.gitignore
+++ b/pds_setup/.gitignore
@@ -1,0 +1,7 @@
+.modules/
+.resource_types/
+bolt-debug.log
+.plan_cache.json
+.plugin_cache.json
+.task_cache.json
+.rerun.json

--- a/pds_setup/bolt-project.yaml
+++ b/pds_setup/bolt-project.yaml
@@ -1,0 +1,3 @@
+---
+name: pds_setup
+modules: []

--- a/pds_setup/files/task_helper.rb
+++ b/pds_setup/files/task_helper.rb
@@ -1,0 +1,64 @@
+require 'json'
+
+class TaskHelper
+  class Error < RuntimeError
+    attr_reader :kind, :details, :issue_code
+
+    def initialize(msg, kind, details = nil)
+      super(msg)
+      @kind = kind
+      @issue_code = issue_code
+      @details = details || {}
+    end
+
+    def to_h
+      { 'kind' =>  kind,
+        'msg' => message,
+        'details' => details }
+    end
+  end
+
+  def task(_params = {})
+    msg = 'The task author must implement the `task` method in the task'
+    raise TaskHelper::Error.new(msg, 'tasklib/not-implemented')
+  end
+
+  # Accepts a Data object and returns a copy with all hash keys
+  # symbolized.
+  def self.walk_keys(data)
+    if data.is_a? Hash
+      data.each_with_object({}) do |(k, v), acc|
+        v = walk_keys(v)
+        acc[k.to_sym] = v
+      end
+    elsif data.is_a? Array
+      data.map { |v| walk_keys(v) }
+    else
+      data
+    end
+  end
+
+  def self.run
+    input = STDIN.read
+    params = walk_keys(JSON.parse(input))
+
+    # This method accepts a hash of parameters to run the task, then executes
+    # the task. Unhandled errors are caught and turned into an error result.
+    # @param [Hash] params A hash of params for the task
+    # @return [Hash] The result of the task
+    result = new.task(**params)
+
+    if result.class == Hash
+      STDOUT.print JSON.generate(result)
+    else
+      STDOUT.print result.to_s
+    end
+  rescue TaskHelper::Error => e
+    STDOUT.print({ _error: e.to_h }.to_json)
+    exit 1
+  rescue StandardError => e
+    error = TaskHelper::Error.new(e.message, e.class.to_s, 'stacktrace' => e.backtrace)
+    STDOUT.print({ _error: error.to_h }.to_json)
+    exit 1
+  end
+end

--- a/pds_setup/inventory.yaml
+++ b/pds_setup/inventory.yaml
@@ -1,0 +1,6 @@
+config:
+  transport: ssh
+  ssh:
+    user: root
+    private-key: ~/.ssh/id_rsa-acceptance
+    host-key-check: false

--- a/pds_setup/lib/helpers/node_groups.rb
+++ b/pds_setup/lib/helpers/node_groups.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'hocon'
+require 'puppet'
+
+# rubocop:disable Style/ClassAndModuleChildren
+module Helpers
+  module NodeGroups
+
+    # May be overwritten for testing.
+    def self.enterprise_module_path
+      '/opt/puppetlabs/server/data/environments/enterprise/modules'
+    end
+
+    def require_module_lib(module_name)
+      lib_path = "#{Helpers::NodeGroups.enterprise_module_path}/#{module_name}/lib"
+
+      $LOAD_PATH << lib_path unless $LOAD_PATH.include?(lib_path)
+    end
+
+    # Add pe_install and pe_manager to the Ruby load path.
+    # Initialize Puppet so that the pe_node_groups tool can make use of
+    # the Puppet::Network::HttpPool for communication.
+    # Require the tools we need from the modules.
+    def initialize_pe_modules
+      Puppet.initialize_settings(['--libdir=/dev/null', '--factpath=/dev/null'])
+      require_module_lib('pe_install')
+      require_module_lib('pe_manager')
+      require 'puppet_x/util/classification'
+      require 'puppet_x/util/service_status'
+      require 'puppet/util/pe_node_groups'
+    end
+
+    def get_service_on_primary(service)
+      if PuppetX::Util::ServiceStatus.respond_to?(:get_service_on_primary)
+        # Method was added in 2018.1.9...
+        PuppetX::Util::ServiceStatus.get_service_on_primary(service)
+      else
+        config = PuppetX::Util::ServiceStatus.load_services_config
+        nodes_config = PuppetX::Util::ServiceStatus.load_nodes_config
+        primary_node = nodes_config.find { |node| node[:role] == 'primary_master' }
+        config.find { |svc| svc[:type] == service && svc[:node_certname] == primary_node[:certname] }
+      end
+    end
+
+    # Handle to the PE Classifier service as defined for the primary
+    # in the local /etc/puppetlabs/client-tools/services.conf file.
+    def classifier
+      unless @nc
+        @nc_service = get_service_on_primary('classifier')
+        @nc = Puppet::Util::Pe_node_groups.new(@nc_service[:server], @nc_service[:port].to_i, "/#{@nc_service[:prefix]}")
+      end
+      @nc
+    end
+
+    # @return [Array<Hash>] All the Classifier Node Groups as returned by the
+    #   groups end point.
+    def all_groups
+      unless @all_groups
+        @all_groups = classifier.get_groups
+      end
+      @all_groups
+    end
+
+    # @param name [String] The group name to look up.
+    # @return [Hash] The specific PE Node Group hash matching the given name.
+    def get_group(name, refresh: false)
+      @all_groups = nil if refresh
+      group = PuppetX::Util::Classifier.find_group(all_groups, name)
+      group
+    end
+
+    def get_group_and_descendents(name)
+      parent = get_group(name)
+      children = all_groups.select { |g| g['parent'] == parent['id'] }
+      descendents = children.map { |c| get_group_and_descendents(c['name']) }
+      [parent, descendents].flatten.sort { |a, b| a['name'] <=> b['name'] } # rubocop:disable Performance/CompareWithBlock
+    end
+
+    def update_group(group_delta)
+      classifier.update_group(group_delta)
+    rescue Puppet::Error => e
+      raise(e)
+    end
+  end
+end

--- a/pds_setup/lib/helpers/puppet_helper.rb
+++ b/pds_setup/lib/helpers/puppet_helper.rb
@@ -1,0 +1,57 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+# rubocop:disable Style/ClassAndModuleChildren
+module Helpers
+  module PuppetHelper
+    def puppet_bin
+      if Gem.win_platform?
+        require 'win32/registry'
+        installed_dir =
+          begin
+            Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Puppet Labs\Puppet') do |reg|
+              # rubocop:disable Style/RescueModifier
+              # Rescue missing key
+              dir = reg['RememberedInstallDir64'] rescue ''
+              # Both keys may exist, make sure the dir exists
+              break dir if File.exist?(dir)
+
+              # Rescue missing key
+              reg['RememberedInstallDir'] rescue ''
+              # rubocop:enable Style/RescueModifier
+            end
+          rescue Win32::Registry::Error
+            # Rescue missing registry path
+            ''
+          end
+
+        path =
+          if installed_dir.empty?
+            ''
+          else
+            File.join(installed_dir, 'bin', 'puppet.bat')
+          end
+      else
+        path = '/opt/puppetlabs/puppet/bin/puppet'
+      end
+      path
+    end
+
+    def catalog_path
+      if Gem.win_platform?
+        'C:/ProgramData/PuppetLabs/puppet/cache/client_data/catalog/'
+      else
+        '/opt/puppetlabs/puppet/cache/client_data/catalog/'
+      end
+    end
+
+    def csr_attributes_file
+      if Gem.win_platform?
+        'C:/ProgramData/PuppetLabs/puppet/etc/csr_attributes.yaml'
+      else
+        '/etc/puppetlabs/puppet/csr_attributes.yaml'
+      end
+    end
+
+  end
+end

--- a/pds_setup/plans/configure_pds.pp
+++ b/pds_setup/plans/configure_pds.pp
@@ -1,0 +1,75 @@
+#This plan will pull down a PE tarball from artifactory, install it on a node, and set up Puppet Data service to be served from the primary server acting as both the pds database and pds server.
+#For now, the database and server params are set to the primary fqdn only; this is not tested on standalone postgres nodes
+#TODO - make the setup configurable to use nodes other than primary
+#TODO - support the use of compilers as pds database hosts
+# @param fdqn The fqdn of the to-be puppet data service.
+# @param control_repo_url The url to the control repository (remote or local, default git@github.com:puppetlabs/pds-integration-control-repo)
+# @param control_repo_private_key_path If the repo requires a key to reach,
+#   this is the absolute path to the location of the key on the primary (default /root/id-control_repo)
+# @param install_pe install a fresh PE on given node (default true)
+# @param platform platform type for PE tarball (default el-7-x86_64)
+# @param version The PE version for the install (default 2021.5.0).
+plan pds_setup::configure_pds(
+  TargetSpec $fqdn,
+  String $control_repo_url	= "git@github.com:puppetlabs/pds-integration-control-repo",
+  String $control_repo_private_key_path	= "/root/id-control_repo",
+  Boolean $install_pe = true,
+  String $platform	= "el-7-x86_64",
+  String $version	= "2021.5.0"
+) {
+
+  if install_pe {
+    run_task(pds_setup::get_pe_and_install, $fqdn, version => $version, platform_tag => $platform)
+    #Run puppet twice as recommended by installer
+    out::message('Puppet Run 1')
+    run_task(pds_setup::run_puppet, $fqdn)
+    out::message('Puppet Run 2')
+    run_task(pds_setup::run_puppet, $fqdn)
+  }
+
+  upload_file($control_repo_private_key_path, '/root/id-control_repo', $fqdn)
+  run_task(pds_setup::setup_code_manager, $fqdn, r10k_remote => $control_repo_url, r10k_private_key => '/root/id-control_repo' )
+  run_task('pds_setup::update_node_group', $fqdn,
+    'group_name'       => 'PE Master',
+    'class_parameters' => {
+      'puppet_enterprise::profile::master' => {
+        'code_manager_auto_configure' => true,
+        'r10k_remote'                 => $control_repo_url,
+        'r10k_private_key'            => '/etc/puppetlabs/puppetserver/ssh/id-control_repo',
+      }
+    },
+  )
+
+  out::message('Puppet Run post codemanager changes')
+  run_task(pds_setup::run_puppet, $fqdn)
+  run_command('puppet code deploy production --wait', $fqdn)
+  out::message('Puppet Run post code repo deploy')
+  run_task(pds_setup::run_puppet, $fqdn)
+
+  run_task('pds_setup::update_node_group', $fqdn,
+    'group_name'       => 'PE Master',
+    'class_parameters' => {
+      'puppet_data_service::database' => {
+      }
+    },
+  )
+  run_task(pds_setup::run_puppet, $fqdn)
+  $uuid = run_command("uuidgen", $fqdn).first['stdout'].strip
+  out::message("PDS Admin user UUID: ${uuid}")
+  run_task('pds_setup::update_node_group', $fqdn,
+    'group_name'        => 'PE Master',
+    'class_parameters'  => {
+      'puppet_data_service::server' => {
+        'database_host' => $fqdn,
+      }
+    },
+    'config_data'       => {
+      "puppet_data_service::server" => {
+        "pds_token" => $uuid
+      }
+    }
+  )
+  run_task(pds_setup::run_puppet, $fqdn)
+
+
+}

--- a/pds_setup/tasks/get_pe_and_install.json
+++ b/pds_setup/tasks/get_pe_and_install.json
@@ -1,0 +1,22 @@
+{
+"description": "Download and unpack the correct pe tarball for the platform",
+  "input_method": "environment",
+  "parameters": {
+    "platform_tag": {
+      "description": "The primary platform os-ver-arch tag we will install on. Needed to construct the tarball url",
+      "type": "String"
+    },
+    "version": {
+      "description": "The version of pe. Needed to construct the tarball url. Takes precedence over pe_family if given.",
+      "type": "Optional[String]"
+    },
+    "family": {
+      "description": "The first two version numbers of a PE release (2019.1 for example). If no version is provided, this may be specified to pull the latest tarball from ci-ready instead.",
+      "type": "Optional[String]"
+    },
+    "workdir": {
+      "description": "The directory in which to download and unpack the PE tarball. (Default: '/root)'",
+      "type": "Optional[String]"
+    }
+  }
+}

--- a/pds_setup/tasks/get_pe_and_install.sh
+++ b/pds_setup/tasks/get_pe_and_install.sh
@@ -1,0 +1,99 @@
+#! /usr/bin/env bash
+
+set -e
+
+# shellcheck disable=SC2154
+platform_tag=$PT_platform_tag
+# shellcheck disable=SC2154
+pe_version=$PT_version
+# shellcheck disable=SC2154
+pe_family=$PT_family
+# shellcheck disable=SC2154
+workdir=${PT_workdir:-/root}
+
+if [ -z "$pe_version" ] && [ -z "$pe_family" ]; then
+  echo "Must set either version or family" >&2
+  exit 1
+fi
+
+cd "$workdir"
+
+if [ -n "$pe_version" ]; then
+  pe_family=$(echo "$pe_version" | grep -oE '^[0-9]+\.[0-9]+')
+fi
+
+if [[ "$pe_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  release_version='true'
+  base_url="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/${pe_version}"
+elif [[ "$pe_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
+  release_version='true'
+  base_url="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/internal/${pe_family}"
+else
+  pe_major="${pe_family%.*}"
+
+  # 2021 dev builds are actually all under 'main'
+  if [ "$pe_major" -eq 2021 ]; then
+    pe_branch='main'
+  fi
+
+  base_url="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/${pe_branch:-$pe_family}/ci-ready"
+fi
+
+if [ -z "$pe_version" ]; then
+  pe_version=$(curl "${base_url}/LATEST")
+fi
+
+pe_dir="puppet-enterprise-${pe_version}-${platform_tag}"
+
+if [ "$release_version" == 'true' ]; then
+  pe_tarball="${pe_dir}.tar.gz"
+else
+  pe_tarball="${pe_dir}.tar"
+fi
+
+pe_tarball_url="${base_url}/${pe_tarball}"
+
+wget_code=0
+tar_code=0
+
+set +e
+if [ ! -f "${pe_tarball}" ]; then
+  wget -nv --quiet "${pe_tarball_url}"
+  wget_code=$?
+fi
+if [ ! -d "${pe_dir}" ]; then
+  tar -xf "${pe_tarball}"
+  tar_code=$?
+fi
+set -e
+
+if [ "$wget_code" != 0 ] || [ "$tar_code" != 0 ]; then
+  echo "{
+  \"_error\": {
+    \"msg\": \"Failed either to wget or untar the PE tarball from ${pe_tarball_url}\",
+    \"kind\": \"enterprise_tasks/get_pe\",
+    \"details\": {
+      \"wget_exit_code\": \"${wget_code}\",
+      \"tar_exit_code\": \"${tar_code}\",
+      \"pe_tarball_url\": \"${pe_tarball_url}\",
+      \"pe_tarball\": \"${pe_tarball}\",
+      \"pe_dir\": \"${pe_dir}\"
+    }
+  }
+}"
+  exit 1
+fi
+
+echo "{
+  \"workdir\":\"${workdir}\",
+  \"pe_dir\":\"${workdir}/${pe_dir}\",
+  \"pe_tarball\":\"${pe_tarball}\",
+  \"pe_tarball_url\":\"${pe_tarball_url}\",
+  \"pe_family\":\"${pe_family}\",
+  \"pe_version\":\"${pe_version}\"
+}"
+
+${workdir}/${pe_dir}/puppet-enterprise-installer -y -c ${workdir}/${pe_dir}/conf.d/pe.conf
+echo "install complete"
+puppet infra console_password --password puppetlabs
+echo "admin password changed to 'puppetlabs'"

--- a/pds_setup/tasks/run_puppet.json
+++ b/pds_setup/tasks/run_puppet.json
@@ -1,0 +1,30 @@
+{
+  "description": "Run puppet on a given host",
+  "files": [
+    "pds_setup/files/task_helper.rb",
+    "pds_setup/lib/helpers/puppet_helper.rb"
+  ],
+  "input_method": "stdin",
+  "parameters": {
+    "alternate_host": {
+      "description": "The certname of a different primary (can be used post-replica-promotion when running Puppet on a forgotten primary)",
+      "type": "Optional[String[1]]"
+    },
+    "exit_codes": {
+      "description": "Valid exit codes for the puppet run",
+      "type": "Optional[Array]"
+    },
+    "max_timeout": {
+      "description": "The maximum amount of time to wait and retry before failing",
+      "type": "Optional[Integer]"
+    },
+    "env_vars": {
+      "description": "Environment variables to be set with the associated puppet run",
+      "type": "Optional[Hash]"
+    },
+    "additional_args": {
+      "description": "Additional arguments to pass to the puppet agent -t command. This should be an array of strings, with each argument an element in the array.",
+      "type": "Optional[Array]"
+    }
+  }
+}

--- a/pds_setup/tasks/run_puppet.rb
+++ b/pds_setup/tasks/run_puppet.rb
@@ -1,0 +1,49 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require_relative '../files/task_helper.rb'
+require_relative '../lib/helpers/puppet_helper.rb'
+require 'open3'
+
+class RunPuppet < TaskHelper
+  include Helpers::PuppetHelper
+
+  def task(alternate_host: nil, exit_codes: [0, 2], max_timeout: 0, env_vars: {}, additional_args: nil, **_kwargs)
+    # This is necessary because TaskHelper#walk_keys() recursively symbolizes for named parameters and Open3 expects strings
+    env = env_vars.each_with_object({}) do |e, hash|
+      hash[e[0].to_s] = e[1].to_s
+    end
+    cmd = [puppet_bin, 'config', 'print', 'certname']
+    certname = Open3.capture2e(*cmd)[0].strip
+    puppet_cmd = [puppet_bin, 'agent', '-t','--color', 'false', '--no-noop', '--no-use_cached_catalog']
+    if alternate_host
+      puppet_cmd << '--server_list'
+      puppet_cmd << "#{alternate_host}:8140"
+    end
+
+    puppet_cmd += additional_args if additional_args
+
+    if max_timeout.zero?
+      output, status = Open3.capture2e(env, *puppet_cmd)
+    else
+      timeout = 1
+      while timeout < max_timeout
+        output, status = Open3.capture2e(env, *puppet_cmd)
+        # We only want to wait for a run in progress. If we exit
+        # with an unallowed exit code, we don't want to keep
+        # doing puppet runs until timeout.
+        break unless status.exitstatus == 1 && output =~ /Run of Puppet configuration client already in progress/
+        sleep(timeout)
+        timeout *= 2
+      end
+    end
+
+    if !exit_codes.include? status.exitstatus
+      raise TaskHelper::Error.new("Running puppet failed on host with certname #{certname}. Output: #{output}", 'puppetlabs.run-puppet/run-puppet-failed', 'output' => output)
+    end
+
+    result = { _output: output }
+    result.to_json
+  end
+end
+
+RunPuppet.run if __FILE__ == $PROGRAM_NAME

--- a/pds_setup/tasks/setup_code_manager.json
+++ b/pds_setup/tasks/setup_code_manager.json
@@ -1,0 +1,14 @@
+{
+  "description": "Set up codemanager and point to a remote repository",
+  "input_method": "environment",
+  "parameters": {
+      "r10k_remote": {
+	  "description": "git link to remote code repo",
+	  "type": "String"
+      },
+      "r10k_private_key": {
+          "description": "path to key used in r10k remote",
+          "type": "String"
+      }
+  }
+}

--- a/pds_setup/tasks/setup_code_manager.sh
+++ b/pds_setup/tasks/setup_code_manager.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+
+KEYPATH=$PT_r10k_private_key
+mv $KEYPATH /etc/puppetlabs/puppetserver/ssh/id-control_repo
+chown pe-puppet:pe-puppet /etc/puppetlabs/puppetserver/ssh/id-control_repo
+echo puppetlabs | puppet access login --lifetime 5y --username admin

--- a/pds_setup/tasks/update_node_group.json
+++ b/pds_setup/tasks/update_node_group.json
@@ -1,0 +1,25 @@
+{
+  "description": "Update parameters of a Classifier Node Group.",
+  "files": [
+    "pds_setup/lib/helpers/node_groups.rb",
+    "pds_setup/files/task_helper.rb"
+  ],
+  "input_method": "stdin",
+  "parameters": {
+    "group_name": {
+      "description": "The name of the node group to make changes to.",
+      "type": "String[1]"
+    },
+    "class_parameters": {
+      "description": "A hash of hashes, keyed by class names. Each value hash must be keyed by the parameter name. Null values will remove the parameter or class, respectively.",
+      "type": "Hash[String,Optional[Hash[String,Optional[Variant[String,Boolean,Numeric,Array,Hash]]]]]"
+    },
+    "config_data": {
+      "description": "A hash of hashes, keyed by class names. Each value hash must be keyed by the parameter name. Null values will remove the parameter or class, respectively.",
+      "type": "Optional[Hash[String,Optional[Hash[String,Optional[Variant[String,Boolean,Numeric,Array,Hash]]]]]]"
+    }
+
+    
+  },
+  "private": true
+}

--- a/pds_setup/tasks/update_node_group.rb
+++ b/pds_setup/tasks/update_node_group.rb
@@ -1,0 +1,36 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require_relative '../lib/helpers/node_groups'
+require_relative '../files/task_helper.rb'
+
+class UpdateNodeGroup < TaskHelper
+  include Helpers::NodeGroups
+
+  def task(group_name:, class_parameters:, config_data: {}, **_kwargs)
+    initialize_pe_modules
+    group = get_group(group_name)
+
+    if !config_data.empty?
+      update_group({
+        id: group['id'],
+        classes: class_parameters,
+        config_data: config_data
+      })
+    else
+      update_group({
+        id: group['id'],
+        classes: class_parameters,
+      })
+    end
+
+    group = get_group(group_name, refresh: true)
+
+    {
+      success: true,
+      group: group,
+    }
+  end
+end
+
+UpdateNodeGroup.run if __FILE__ == $PROGRAM_NAME


### PR DESCRIPTION
This PR adds a bolt plan that sets up puppet data service to the PE Master node group from scratch on an empty host or a pre-installed PE