### PR TITLE
Add functionality to get command

### DIFF
--- a/servicenow/change_management/SNHttpClient/cmd/get.go
+++ b/servicenow/change_management/SNHttpClient/cmd/get.go
@@ -1,6 +1,11 @@
 package cmd
 
 import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/spf13/cobra"
 )
 
@@ -15,6 +20,14 @@ var getCmd = &cobra.Command{
 	  SNHttpClient get <action>
 		`,
 	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Sending Get request")
+		endpoint, _ := cmd.Flags().GetString("endpoint")
+		fmt.Println("Endpoint: " + endpoint)
+		username, _ := cmd.Flags().GetString("username")
+		fmt.Println("Username: " + username)
+		password, _ := cmd.Flags().GetString("password")
+		fmt.Println("Password: " + password)
+		fmt.Println(GetRecord(endpoint, username, password))
 	},
 
 	Args: func(cmd *cobra.Command, args []string) error {
@@ -27,4 +40,20 @@ var getCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(getCmd)
 	getCmd.AddCommand(nodesCmd)
+}
+
+func GetRecord(endpoint string, username string, password string) string {
+	client := &http.Client{}
+	body := []byte(`{
+	"short_description": "Get record"
+}`)
+	req, err := http.NewRequest("GET", endpoint, bytes.NewBuffer(body))
+	req.SetBasicAuth(username, password)
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+	}
+	bodyText, err := ioutil.ReadAll(resp.Body)
+	x := string(bodyText)
+	return x
 }


### PR DESCRIPTION
This P Radds functionality to the cli get command. it currently requires the entire endpoint to be flagged in along with uname pass. In the future we will shorten the endpoint requirements and use oauth where applicable