### PR TITLE
(PIE-1241) Update .gitignore

### DIFF
--- a/servicenow/change_management/ServiceNowHTTPClient/.gitignore
+++ b/servicenow/change_management/ServiceNowHTTPClient/.gitignore
@@ -1,4 +1,26 @@
-.cobra.yaml
-go.sum
-SNHttpClient
-go.mod
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+#Ignores all binaries except go files
+**/*
+!**/*.go
+!**/
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work


### PR DESCRIPTION
gitignore should not ignore mod and sum files, as per best practices. This PR updates the gitignore to add commonly ignored files, as well as a way to ignore any executables created that are not .go files