### PR TITLE
(PIE-1248) Add update change command

### DIFF
--- a/servicenow/change_management/ServiceNowHTTPClient/cmd/attributes.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/cmd/attributes.go
@@ -29,9 +29,8 @@ var getAttributeCommand = &cobra.Command{
 			" username=", username+
 			" password=", password+"\n")
 
-		str := internal.GetChangeRaw(endpoint, username, password)
-		var j = []byte(str)
-		v, err := jason.NewObjectFromBytes(j)
+		chg := internal.GetChangeRaw(endpoint, username, password)
+		v, err := jason.NewObjectFromBytes(chg)
 
 		if err != nil {
 			panic(err)
@@ -48,11 +47,9 @@ var getAttributeCommand = &cobra.Command{
 
 			myMap := v.Map()
 
-			for k, _ := range myMap {
+			for k := range myMap {
 				fmt.Println(k)
 			}
-
-			break
 		}
 	},
 
@@ -60,8 +57,6 @@ var getAttributeCommand = &cobra.Command{
 		return nil
 	},
 }
-
-// ScannerVersion is the version of the scanner associated with the benchmark.
 
 func init() {
 }

--- a/servicenow/change_management/ServiceNowHTTPClient/cmd/change.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/cmd/change.go
@@ -35,7 +35,86 @@ var changeCmd = &cobra.Command{
 
 		fmt.Println("Creating Change in SN... with body from file: " + filename)
 		response := internal.CreateChange(endpoint, body, username, password)
-		fmt.Println("created change ID = ", response.Name, " sys_id =", response.SysID)
+
+		name := response.Result.Number.DisplayValue
+		sysid := response.Result.SysID.DisplayValue
+
+		change := fmt.Sprintf("ChangeID: %s, SysID: %s", name, sysid)
+
+		fmt.Println(change)
+	},
+
+	Args: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+}
+
+// getChangeCommand gets changes from SN
+var getChangeCommand = &cobra.Command{
+	Use:   "change",
+	Short: "Gets all Change Request objects from the SN CMDB by user",
+	Long: `Gets all change request object from SN by user'
+
+	Example usage:
+	  SNHttpClient get change <user>
+		`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Your arguments were: [" + strings.Join(args, ",") + "]")
+		endpoint := viper.GetString("endpoint")
+		username := viper.GetString("username")
+		password := viper.GetString("password")
+
+		fmt.Print("endpoint=", endpoint+
+			" username=", username+
+			" password=", password+"\n")
+
+		internal.GetChange(endpoint, username, password)
+	},
+
+	Args: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+}
+
+// updateChangeCmd updates a change in SN
+var updateChangeCmd = &cobra.Command{
+	Use:   "change",
+	Short: "Updates a Change Request object in the SN CMDB",
+	Long: `Updates a change request in SN.
+
+	Example usage:
+	  SNHttpClient update change --sys_id <9d385017c611228701d22104cc95c371> --state <assess>
+		`,
+	Run: func(cmd *cobra.Command, args []string) {
+		endpoint := viper.GetString("endpoint")
+		username := viper.GetString("username")
+		password := viper.GetString("password")
+		sys_id, _ := cmd.Flags().GetString("sys_id")
+		state, _ := cmd.Flags().GetString("state")
+
+		//
+		// Process changes in bulk. This still needs a way to grab changes with a valid state before updating.
+		//
+		// changeMap := internal.GetChange(endpoint, username, password)
+		// for _, sys_id := range changeMap {
+		//   response := internal.UpdateChange(endpoint, sys_id, state, username, password)
+		//   name := response.Result.Number.DisplayValue
+		//   sysid := response.Result.SysID.DisplayValue
+		//   up_state := response.Result.State.DisplayValue
+		//
+		//   change := fmt.Sprintf("ChangeID: %s, SysID: %s, State: %s", name, sysid, up_state)
+		//   fmt.Println(change)
+		// }
+		//
+
+		response := internal.UpdateChange(endpoint, sys_id, state, username, password)
+
+		name := response.Result.Number.DisplayValue
+		sysid := response.Result.SysID.DisplayValue
+		up_state := response.Result.State.DisplayValue
+
+		change := fmt.Sprintf("ChangeID: %s, SysID: %s, State: %s", name, sysid, up_state)
+		fmt.Println(change)
 	},
 
 	Args: func(cmd *cobra.Command, args []string) error {
@@ -46,8 +125,8 @@ var changeCmd = &cobra.Command{
 // deleteChangeCommand deletes changes from SN
 var deleteChangeCmd = &cobra.Command{
 	Use:   "changes",
-	Short: "Runs a delete command",
-	Long: `Running delete on a user.
+	Short: "Deletes Change Request objects in the SN CMDB",
+	Long: `Deletes change requests in SN.
 
 	Example usage:
 	  SNHttpClient delete changes 
@@ -72,35 +151,6 @@ var deleteChangeCmd = &cobra.Command{
 		return nil
 	},
 }
-
-// getChangeCommand gets changes from SN
-var getChangeCommand = &cobra.Command{
-	Use:   "change",
-	Short: "Gets a Change object from the SN CMDB by user",
-	Long: `Gets a Change object from the SN CMDB by user'
-
-	Example usage:
-	  SNHttpClient get change <user>
-		`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Your arguments were: [" + strings.Join(args, ",") + "]")
-		endpoint := viper.GetString("endpoint")
-		username := viper.GetString("username")
-		password := viper.GetString("password")
-
-		fmt.Print("endpoint=", endpoint+
-			" username=", username+
-			" password=", password+"\n")
-
-		internal.GetChange(endpoint, username, password)
-	},
-
-	Args: func(cmd *cobra.Command, args []string) error {
-		return nil
-	},
-}
-
-// ScannerVersion is the version of the scanner associated with the benchmark.
 
 func init() {
 }

--- a/servicenow/change_management/ServiceNowHTTPClient/cmd/change.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/cmd/change.go
@@ -60,9 +60,9 @@ var getChangeCommand = &cobra.Command{
 		`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Your arguments were: [" + strings.Join(args, ",") + "]")
-		endpoint := viper.GetString("endpoint")
-		username := viper.GetString("username")
-		password := viper.GetString("password")
+		endpoint := viper.GetString("servicenow.endpoint")
+		username := viper.GetString("servicenow.username")
+		password := viper.GetString("servicenow.password")
 
 		fmt.Print("endpoint=", endpoint+
 			" username=", username+
@@ -86,9 +86,9 @@ var updateChangeCmd = &cobra.Command{
 	  SNHttpClient update change --sys_id <9d385017c611228701d22104cc95c371> --state <assess>
 		`,
 	Run: func(cmd *cobra.Command, args []string) {
-		endpoint := viper.GetString("endpoint")
-		username := viper.GetString("username")
-		password := viper.GetString("password")
+		endpoint := viper.GetString("servicenow.endpoint")
+		username := viper.GetString("servicenow.username")
+		password := viper.GetString("servicenow.password")
 		sys_id, _ := cmd.Flags().GetString("sys_id")
 		state, _ := cmd.Flags().GetString("state")
 
@@ -132,9 +132,9 @@ var deleteChangeCmd = &cobra.Command{
 	  SNHttpClient delete changes 
 		`,
 	Run: func(cmd *cobra.Command, args []string) {
-		endpoint := viper.GetString("endpoint")
-		username := viper.GetString("username")
-		password := viper.GetString("password")
+		endpoint := viper.GetString("servicenow.endpoint")
+		username := viper.GetString("servicenow.username")
+		password := viper.GetString("servicenow.password")
 
 		fmt.Println("Running delete command... ")
 		fmt.Println("endpoint=", endpoint+" username=", username+" password=", password+"\n")

--- a/servicenow/change_management/ServiceNowHTTPClient/cmd/create.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/cmd/create.go
@@ -15,7 +15,7 @@ var createCmd = &cobra.Command{
 
 	change/relationship/actions are supported.
 	Example usage:
-	  SNHttpClient create change|relationship|action>
+	  SNHttpClient create <change|relationship>
 		`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("You're arguments were: " + strings.Join(args, ","))
@@ -23,13 +23,11 @@ var createCmd = &cobra.Command{
 	},
 
 	Args: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("Error: must also specify a resource like change, relationship, or action")
+		fmt.Println("error: Must use update with subcommand change or relationship")
 
 		return nil
 	},
 }
-
-// ScannerVersion is the version of the scanner associated with the benchmark.
 
 func init() {
 	rootCmd.AddCommand(createCmd)

--- a/servicenow/change_management/ServiceNowHTTPClient/cmd/delete.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/cmd/delete.go
@@ -7,12 +7,12 @@ import (
 // deleteCmd runs a delete action
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
-	Short: "Gets an object from the SN CMDB",
-	Long: `Facilitates the execution of actions.
+	Short: "Deletes Change Request objects in the SN CMDB",
+	Long: `Deletes change requests in SN.
+  
 
-	nodes/change/relationship/ actions are supported.
 	Example usage:
-	  SNHttpClient get <action>
+	  SNHttpClient delete changes
 		`,
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/servicenow/change_management/ServiceNowHTTPClient/cmd/demo.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/cmd/demo.go
@@ -39,7 +39,7 @@ var demoCmd = &cobra.Command{
 
 		fmt.Println("Creating Change in SN... with body from file: " + filename)
 		response := internal.CreateChange(endpoint, body, username, password)
-		fmt.Println("Change ID = ", response.Name, " Sys ID=", response.SysID)
+
 		//Getting sys_id of change
 
 		//Going to get nodes from SN. Will return map of nodes and their sys_id
@@ -51,7 +51,7 @@ var demoCmd = &cobra.Command{
 		payloadStrNodes := strings.Join(nodesSlice, ",")
 		fmt.Println("payloadStrNodes=", payloadStrNodes)
 
-		internal.CreateRelationship(endpoint, response.SysID, payloadStrNodes, username, password)
+		internal.CreateRelationship(endpoint, response.Result.SysID.DisplayValue, payloadStrNodes, username, password)
 	},
 
 	Args: func(cmd *cobra.Command, args []string) error {

--- a/servicenow/change_management/ServiceNowHTTPClient/cmd/get.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/cmd/get.go
@@ -7,12 +7,12 @@ import (
 // initCmd is a subcommand to StoreCmd that ads a Benchmark to the store.
 var getCmd = &cobra.Command{
 	Use:   "get",
-	Short: "Gets an object from the SN CMDB",
-	Long: `Facilitates the execution of actions.
+	Short: "Gets objects from the SN CMDB",
+	Long: `Gets objects from SN'
 
-	nodes/change/relationship/ actions are supported.
+	nodes/change/attributes subcommands are supported.
 	Example usage:
-	  SNHttpClient get <action>
+	  SNHttpClient get <nodes|change|attributes>
 		`,
 	Run: func(cmd *cobra.Command, args []string) {
 
@@ -22,8 +22,6 @@ var getCmd = &cobra.Command{
 		return nil
 	},
 }
-
-// ScannerVersion is the version of the scanner associated with the benchmark.
 
 func init() {
 	rootCmd.AddCommand(getCmd)

--- a/servicenow/change_management/ServiceNowHTTPClient/cmd/nodes.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/cmd/nodes.go
@@ -32,8 +32,6 @@ var nodesCmd = &cobra.Command{
 	},
 }
 
-// ScannerVersion is the version of the scanner associated with the benchmark.
-
 func init() {
 }
 
@@ -53,10 +51,13 @@ func GetRecord(endpoint string, username string, password string) map[string]str
 
 	URL := "https://" + endpoint + "/api/now/table/cmdb_ci_computer?sysparm_query=active=true&sysparm_fields=fqdn,sys_id"
 
-	result := internal.HTTPAction("GET", URL, body, username, password)
+	result, err := internal.HTTPAction("GET", URL, body, username, password)
+	if err != nil {
+		panic(err)
+	}
 
 	var data Result
-	json.Unmarshal([]byte(result), &data)
+	json.Unmarshal(result, &data)
 	resultMap := make(map[string]string)
 	for _, v := range data.Result {
 		resultMap[string(v.Certname)] = string(v.SysID)

--- a/servicenow/change_management/ServiceNowHTTPClient/cmd/relationship.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/cmd/relationship.go
@@ -16,7 +16,7 @@ var relationshipCmd = &cobra.Command{
 	Long: `Creates a Relationship request in SN.
 
 	Example usage:
-	  SNHttpClient create relationship <endpoint> <username> <password>
+	  SNHttpClient create relationship
 		`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Your arguments were: [" + strings.Join(args, ",") + "]")
@@ -25,7 +25,7 @@ var relationshipCmd = &cobra.Command{
 		password := viper.GetString("password")
 
 		if len(args) < 2 {
-			fmt.Println("You must provide a changeID and node Node SysID")
+			fmt.Println("You must provide a change SysID and node SysID")
 			fmt.Println("Example: SNHttpClient create relationship 1234567890abcdef1234567890abcdef 1234567890abcdef1234567890abcdef")
 			return
 		}
@@ -44,8 +44,6 @@ var relationshipCmd = &cobra.Command{
 		return nil
 	},
 }
-
-// ScannerVersion is the version of the scanner associated with the benchmark.
 
 func init() {
 }

--- a/servicenow/change_management/ServiceNowHTTPClient/cmd/root.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/cmd/root.go
@@ -9,8 +9,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-var cfgFile string
-
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "SNHttpClient",

--- a/servicenow/change_management/ServiceNowHTTPClient/cmd/run.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/cmd/run.go
@@ -7,12 +7,11 @@ import (
 // initCmd is a subcommand to StoreCmd that ads a Benchmark to the store.
 var runCmd = &cobra.Command{
 	Use:   "run",
-	Short: "Gets an object from the SN CMDB",
-	Long: `Facilitates the execution of actions.
+	Short: "Run a demo",
+	Long: `Runs a demo command that will do a simple compliance sequence.
 
-	nodes/change/relationship/ actions are supported.
 	Example usage:
-	  SNHttpClient get <action>
+	  SNHttpClient run demo
 		`,
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/servicenow/change_management/ServiceNowHTTPClient/cmd/update.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/cmd/update.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// updateCmd represents the update command
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Updates a Change Request objects in the SN CMDB",
+	Long: `Updates a change request in SN.
+
+	Example usage:
+	  SNHttpClient update change
+		`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+	},
+
+	Args: func(cmd *cobra.Command, args []string) error {
+		fmt.Println("error: Must use update with subcommand change")
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+	updateCmd.AddCommand(updateChangeCmd)
+	updateCmd.PersistentFlags().StringP("sys_id", "i", "", "Change Request sys_id")
+	updateCmd.MarkPersistentFlagRequired("sys_id")
+	updateCmd.PersistentFlags().StringP("state", "s", "", "Change Request state")
+	updateCmd.MarkPersistentFlagRequired("state")
+	updateCmd.MarkFlagsRequiredTogether("sys_id", "state")
+}

--- a/servicenow/change_management/ServiceNowHTTPClient/internal/action.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/internal/action.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Post POST data to ServiceNow
-func Post(host string, username string, password string) string {
+func Post(host string, username string, password string) []byte {
 	URL := "https://" + host + "/api/sn_chg_rest/v1/change"
 	body := []byte(`{
 		"short_description": "Reboot server on scheduled interval"
@@ -13,6 +13,10 @@ func Post(host string, username string, password string) string {
 
 	fmt.Println("Post URL=" + URL + " body=" + string(body))
 
-	str := HTTPAction("POST", URL, body, username, password)
-	return str
+	resp, err := HTTPAction("POST", URL, body, username, password)
+	if err != nil {
+		panic(err)
+	}
+
+	return resp
 }

--- a/servicenow/change_management/ServiceNowHTTPClient/internal/http.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/internal/http.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -12,21 +13,43 @@ import (
 )
 
 // HTTPAction REST Action to ServiceNow
-func HTTPAction(operation string, URL string, body []byte, username string, password string) string {
+func HTTPAction(operation string, URL string, body []byte, username string, password string) ([]byte, error) {
 	client := &http.Client{}
 
 	req, err := http.NewRequest(operation, URL, bytes.NewBuffer(body))
+	if err != nil {
+		fmt.Println(err)
+		panic(err)
+	}
+
 	req.SetBasicAuth(username, password)
 	fmt.Println("req:", req)
+
 	resp, err := client.Do(req)
 	if err != nil {
 		fmt.Println(err)
 		panic(err)
 	}
-	bodyText, err := ioutil.ReadAll(resp.Body)
-	s := string(bodyText)
+
+	resp_body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(err)
+		panic(err)
+	}
+
+	if resp.StatusCode != 200 {
+		var errorChange ChangeError
+		err = json.Unmarshal(resp_body, &errorChange)
+		if err != nil {
+			fmt.Println(err)
+			panic(err)
+		}
+		return nil, fmt.Errorf("error: %s", errorChange.Error.Message)
+	}
+
 	writeActionToFile(operation, URL, body)
-	return s
+
+	return resp_body, nil
 }
 
 // HTTPTokenBasedAction REST Action to ServiceNow
@@ -49,13 +72,12 @@ func HTTPTokenBasedAction(operation string, URL string, body []byte, token strin
 
 // writeActionToFile writes changes to json file
 func writeActionToFile(operation string, URL string, body []byte) {
-	LogActions := viper.GetBool("Logging.ToFile")
-	if LogActions == false {
-		return
-	}
+	LogActions := viper.GetBool("Servicenow.Logging.ToFile")
+	LogFileName := viper.GetString("Servicenow.Logging.Filename")
 
-	LogFileName := viper.GetString("Logging.Filename")
-	if LogActions == true && LogFileName == "" {
+	if !LogActions {
+		return
+	} else if LogFileName == "" && LogActions {
 		panic("LogFileName not set")
 	}
 

--- a/servicenow/change_management/ServiceNowHTTPClient/internal/http.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/internal/http.go
@@ -23,7 +23,9 @@ func HTTPAction(operation string, URL string, body []byte, username string, pass
 	}
 
 	req.SetBasicAuth(username, password)
-	fmt.Println("req:", req)
+
+	// Is there a reason this is being printed?
+	// fmt.Println("req:", req)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/servicenow/change_management/ServiceNowHTTPClient/internal/relationship.go
+++ b/servicenow/change_management/ServiceNowHTTPClient/internal/relationship.go
@@ -44,7 +44,7 @@ type changeResult struct {
 }
 
 // CreateRelationship POST relationship create to ServiceNow
-func CreateRelationship(host string, changeSysID string, nodeSysID string, username string, password string) string {
+func CreateRelationship(host string, changeSysID string, nodeSysID string, username string, password string) []byte {
 	URL := "https://" + host + "/api/sn_chg_rest/v1/change/" + changeSysID + "/ci"
 	body := []byte(`{
 		"cmdb_ci_sys_ids": "[` + nodeSysID + `]",
@@ -53,16 +53,20 @@ func CreateRelationship(host string, changeSysID string, nodeSysID string, usern
 
 	fmt.Println("Post URL=" + URL + " body=" + string(body))
 
-	str := HTTPAction("POST", URL, body, username, password)
-	fmt.Print("Relationship Response: " + str)
-	return str
+	resp, err := HTTPAction("POST", URL, body, username, password)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Print("Relationship Response: " + string(resp))
+	return resp
 }
 
 // ParseRelationship parses the JSON response from ServiceNow
-func ParseRelationship(responseBody string) map[string]string {
+func ParseRelationship(responseBody []byte) map[string]string {
 
 	var data result
-	json.Unmarshal([]byte(responseBody), &data)
+	json.Unmarshal(responseBody, &data)
 	resultMap := make(map[string]string)
 
 	fmt.Println("number of Changes matching user: ", len(data.Result))


### PR DESCRIPTION
# Summary

This PR contains 2 commits, the first adds the `update change` command and required functions to move Change Requests through the lifecycle. The second refactors the client to handle non `200` responses as well as updates the `--help` output for commands and subcommands.