### PR TITLE
Update servicenow-spoke-nightwatch.yml

### DIFF
--- a/.github/workflows/servicenow-spoke-nightwatch.yml
+++ b/.github/workflows/servicenow-spoke-nightwatch.yml
@@ -3,31 +3,55 @@
 
 name: Nightwatch Tests
 on:
-  push:
+  pull_request_target:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+env:
+  # Setting an environment variable with the value of a configuration variable
+  env_var: ${{ vars.MY_USER }}
+  animal: dingo
 
 jobs:
   build:
-    defaults:
-      run:
-        working-directory: /home/runner/work/PIE_tools/PIE_tools/nightwatch
-  
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-        cache-dependency-path: '**/package-lock.json'
-    - run: npm install package-lock.json
-      working-directory: /home/runner/work/PIE_tools/PIE_tools/nightwatch
+      - uses: nanasess/setup-chromedriver@v2
+        name: Setup ChromeDriver and Run
       
+      - run: |
+          echo "Value of SNOW_USERNAME: $env_var"
+          echo "animal: $animal"
+          echo "vars contains ${{ toJSON(vars) }}"
+
+    #   - uses: actions/checkout@v3
+    # - name: Use Node.js ${{ matrix.node-version }}
+    #   uses: actions/setup-node@v3
+    #   with:
+    #     node-version: ${{ matrix.node-version }}
+    #     cache: 'npm'
+    #     cache-dependency-path: '**/package.json'
+
+    # - uses: browser-actions/setup-chrome@v1
+    #   with:
+    #     chrome-version: 'latest'
+    #   id: setup-chrome
+     
+    
+
+    # - run: |
+    #     echo "Value of SNOW_USERNAME: $SNOW_USERNAME"
+    #     echo "Value of secrets SNOW_USERNAME: ${{ toJSON(secrets) }}"
+    #     echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}
+    #     ${{ steps.setup-chrome.outputs.chrome-path }} --version
+    #     export DISPLAY=:99
+    #     sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
+    #     mkdir -p /home/runner/work/PIE_tools/PIE_tools/nightwatch/custom-assertions 
+    #     mkdir -p /home/runner/work/PIE_tools/PIE_tools/nightwatch/custom-commands
+    #     mkdir -p /home/runner/work/PIE_tools/PIE_tools/nightwatch/page-objects 
+    #     mkdir -p /home/runner/work/PIE_tools/PIE_tools/nightwatch/examples
+    #     npm install
+    #     /usr/local/bin/chromedriver --version
+    #     /opt/google/chrome/chrome --version
+    #     npx nightwatch --config nightwatch.conf.js tests/snow_run_command.js
+
+


### PR DESCRIPTION
apparently, there were some changes to how secrets are handled on hooks a while back:

https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

